### PR TITLE
Fix roster save 400 and guard Bugsnag initialization

### DIFF
--- a/src/frontend/app/index.tsx
+++ b/src/frontend/app/index.tsx
@@ -29,8 +29,10 @@ document.addEventListener("DOMContentLoaded", () => {
   const domElement = document.getElementById("main-app");
   if (!domElement) return;
   const root = createRoot(domElement);
-  
-  Bugsnag.leaveBreadcrumb("Starting application...");
+
+  if (bugsnugApiKey) {
+    Bugsnag.leaveBreadcrumb("Starting application...");
+  }
 
   const renderApp = () => {
     root.render(

--- a/src/frontend/app/pages/Tournaments/TournamentId/components/RosterManager/RosterManager.tsx
+++ b/src/frontend/app/pages/Tournaments/TournamentId/components/RosterManager/RosterManager.tsx
@@ -189,11 +189,30 @@ const RosterManager: React.FC<RosterManagerProps> = ({
   // Handle saving the roster
   const handleSaveRoster = async () => {
     try {
+      const playersWithMissingNumbers = roster.players.filter((p) => !p.number?.trim());
+      if (playersWithMissingNumbers.length > 0) {
+        showAlert("Each player must have a jersey number before saving.", "error");
+        return;
+      }
+
+      const normalizedNumbers = roster.players.map((p) => p.number!.trim());
+      const duplicateNumbers = normalizedNumbers.filter(
+        (number, index, allNumbers) => allNumbers.indexOf(number) !== index
+      );
+      if (duplicateNumbers.length > 0) {
+        const uniqueDuplicates = Array.from(new Set(duplicateNumbers));
+        showAlert(
+          `Duplicate jersey numbers: ${uniqueDuplicates.join(", ")}. Please make each player number unique.`,
+          "error"
+        );
+        return;
+      }
+
       // Convert roster to API format
       const players: RosterPlayerModel[] = roster.players.map((p) => ({
         userId: p.userId,
-        number: p.number || null,
-        gender: p.gender || null,
+        number: p.number!.trim(),
+        gender: p.gender?.trim() || null,
       }));
 
       const coaches: RosterStaffModel[] = roster.coaches.map((c) => ({

--- a/src/frontend/app/routes.tsx
+++ b/src/frontend/app/routes.tsx
@@ -23,6 +23,7 @@ const TeamView = lazy(() => import("./pages/TeamView"));
 const TeamManagement = lazy(() => import("./pages/TeamManagement"));
 
 const App = () => {
+  const bugsnagEnabled = Boolean(process.env.BUGSNAG_API_KEY);
   const [redirectTo, setRedirectTo] = useState<string>();
   const { currentData: currentUser, isError, isLoading } = useGetCurrentUserQuery();
   const roles = currentUser?.roles?.map(r => r.roleType);
@@ -55,7 +56,11 @@ const App = () => {
     }
   }, [currentUser, roles]);
 
-  if (currentUser) Bugsnag.setUser(currentUser.userId);
+  useEffect(() => {
+    if (bugsnagEnabled && currentUser?.userId) {
+      Bugsnag.setUser(currentUser.userId);
+    }
+  }, [bugsnagEnabled, currentUser?.userId]);
 
   if (isLoading === true) return <Loader />;
 


### PR DESCRIPTION
## Summary
This PR fixes the roster save failure when updating tournament participants and removes noisy Bugsnag warnings when Bugsnag is not configured.

## Problem
Saving team rosters could fail with a 400 response on the participant roster update endpoint.

UI symptom:
- Failed to save roster

Console symptom:
- Bugsnag.leaveBreadcrumb() was called before Bugsnag.start()
- Bugsnag.setUser() was called before Bugsnag.start()

## Root Cause
- Roster payloads could send null or empty player jersey numbers, while backend models require a non-null number for players.
- Bugsnag APIs were called even when Bugsnag had not been initialized.

## What Changed

### Roster Save Hardening
- Added client-side validation to block save when any player is missing a jersey number.
- Added client-side duplicate jersey number validation before API submit.
- Normalized payload values before submit:
  - number is sent as a trimmed non-null string
  - gender is trimmed and sent as null only when empty

### Bugsnag Guards
- Wrapped breadcrumb creation so it runs only when Bugsnag is configured.
- Wrapped setUser so it runs only when Bugsnag is configured and a user id is present.

## Validation
- Type diagnostics on edited files: no errors.
- Branch created from main and pushed:
  - fix/roster-save-400-main
- Commit:
  - 931bb563 Fix roster save 400 and guard Bugsnag initialization

## Impact
- Prevents avoidable 400 responses from invalid roster payloads.
- Improves user feedback before submit.
- Removes misleading Bugsnag-before-start console warnings.

## Notes
Some console errors such as No Listener: tabs:outgoing.message.ready and cssRules null traces appear to come from browser extensions or injected scripts rather than this app flow.